### PR TITLE
Updated examples of viewer extensions

### DIFF
--- a/docs/viewer/extensions/panel.md
+++ b/docs/viewer/extensions/panel.md
@@ -7,57 +7,48 @@ This section uses the **basic skeleton** from previous section, but let's rename
 As each extension should be a separeted JavaScript file, create a file in the UI folder **/js/dockingpanelextension.js** and copy the following content (which is same as the basic skeleton, except with a different name): 
 
 ```javascript
-// *******************************************
-// Model Summary Extension
-// *******************************************
-function ModelSummaryExtension(viewer, options) {
-    Autodesk.Viewing.Extension.call(this, viewer, options);
-    this.panel = null; // create the panel variable
+class ModelSummaryExtension extends Autodesk.Viewing.Extension {
+    constructor(viewer, options) {
+        super(viewer, options);
+        this._group = null;
+        this._button = null;
+    }
+
+    load() {
+        console.log('ModelSummaryExtension has been loaded');
+        return true;
+    }
+
+    unload() {
+        // Clean our UI elements if we added any
+        if (this._group) {
+            this._group.removeControl(this._button);
+            if (this._group.getNumberOfControls() === 0) {
+                this.viewer.toolbar.removeControl(this._group);
+            }
+        }
+        console.log('ModelSummaryExtension has been unloaded');
+        return true;
+    }
+
+    onToolbarCreated() {
+        // Create a new toolbar group if it doesn't exist
+        this._group = this.viewer.toolbar.getControl('allMyAwesomeExtensionsToolbar');
+        if (!this._group) {
+            this._group = new Autodesk.Viewing.UI.ControlGroup('allMyAwesomeExtensionsToolbar');
+            this.viewer.toolbar.addControl(this._group);
+        }
+
+        // Add a new button to the toolbar group
+        this._button = new Autodesk.Viewing.UI.Button('ModelSummaryExtensionButton');
+        this._button.onClick = (ev) => {
+            // Execute an action here
+        };
+        this._button.setToolTip('Model Summary Extension');
+        this._button.addClass('modelSummaryExtensionIcon');
+        this._group.addControl(this._button);
+    }
 }
-
-ModelSummaryExtension.prototype = Object.create(Autodesk.Viewing.Extension.prototype);
-ModelSummaryExtension.prototype.constructor = ModelSummaryExtension;
-
-ModelSummaryExtension.prototype.load = function () {
-    // any custom initialization required? add here
-    return true;
-};
-
-ModelSummaryExtension.prototype.onToolbarCreated = function () {
-    var _this = this;
-
-    // prepare to execute the button action
-    var modelSummaryToolbarButton = new Autodesk.Viewing.UI.Button('runModelSummaryCode');
-    modelSummaryToolbarButton.onClick = function (e) {
-        
-        // **********************
-        //
-        //
-        // Execute an action here
-        //
-        //
-        // **********************
-
-    };
-    // modelSummaryToolbarButton CSS class should be defined on your .css file
-    // you may include icons, below is a sample class:
-    modelSummaryToolbarButton.addClass('modelSummaryToolbarButton');
-    modelSummaryToolbarButton.setToolTip('Model Summary');
-
-    // SubToolbar
-    this.subToolbar = (this.viewer.toolbar.getControl("MyAppToolbar") ?
-        this.viewer.toolbar.getControl("MyAppToolbar") :
-        new Autodesk.Viewing.UI.ControlGroup('MyAppToolbar'));
-    this.subToolbar.addControl(modelSummaryToolbarButton);
-
-    this.viewer.toolbar.addControl(this.subToolbar);
-};
-
-ModelSummaryExtension.prototype.unload = function () {
-    if (this.viewer.toolbar) this.viewer.toolbar.removeControl(this.subToolbar);
-    if (this.panel) this.panel.setVisible(false);
-    return true;
-};
 
 Autodesk.Viewing.theExtensionManager.registerExtension('ModelSummaryExtension', ModelSummaryExtension);
 ```
@@ -67,7 +58,7 @@ Autodesk.Viewing.theExtensionManager.registerExtension('ModelSummaryExtension', 
 Just like in the basic skeleton, the toolbar button uses a **CSS** styling (see call to `.addClass` on the code). In the **/css/main.css** add the following:
 
 ```css
-.modelSummaryToolbarButton {
+.modelSummaryExtensionIcon {
   background-image: url(https://github.com/encharm/Font-Awesome-SVG-PNG/raw/master/white/png/24/dashboard.png);
   background-size: 24px;
   background-repeat: no-repeat;
@@ -93,115 +84,89 @@ At this point the extension should load with a toolbar icon, but it doesn't do a
 
 ## Enumerate leaf nodes
 
-The Viewer contains all elements on the model, including categories (e.g. families or part definition), so we need to enumerate the leaf nodes, meaning actual instances on the model. The following `.getAllLeafComponents()` function should be added to our extension (anywhere on the file, outside other functions). This is based on [this blog post](https://forge.autodesk.com/blog/enumerating-leaf-nodes-viewer). 
+The Viewer contains all elements on the model, including categories (e.g. families or part definition), so we need to enumerate the leaf nodes, meaning actual instances on the model. The following `getAllLeafComponents()` function should be added to our extension class. This is based on [this blog post](https://forge.autodesk.com/blog/enumerating-leaf-nodes-viewer). 
 
 ```javascript
-ModelSummaryExtension.prototype.getAllLeafComponents = function (callback) {
-    var cbCount = 0; // count pending callbacks
-    var components = []; // store the results
-    var tree; // the instance tree
-
-    function getLeafComponentsRec(parent) {
-        cbCount++;
-        if (tree.getChildCount(parent) != 0) {
-            tree.enumNodeChildren(parent, function (children) {
-                getLeafComponentsRec(children);
-            }, false);
-        } else {
-            components.push(parent);
-        }
-        if (--cbCount == 0) callback(components);
-    }
-    this.viewer.getObjectTree(function (objectTree) {
-        tree = objectTree;
-        var allLeafComponents = getLeafComponentsRec(tree.getRootId());
+getAllLeafComponents(callback) {
+    this.viewer.getObjectTree(function (tree) {
+        let leaves = [];
+        tree.enumNodeChildren(tree.getRootId(), function (dbId) {
+            if (tree.getChildCount(dbId) === 0) {
+                leaves.push(dbId);
+            }
+        }, true);
+        callback(leaves);
     });
-};
+}
 ```
-
-> Note how `.getAllLeafComponents()` if defined as a prototype method of **ModelSummaryExtension**. [Learn more about JavaScript Prototype](https://www.w3schools.com/js/js_object_prototypes.asp).
 
 ## Docking panel
 
 The extension will show the results on a Viewer [property panel](https://developer.autodesk.com/en/docs/viewer/v2/reference/javascript/propertypanel/). Copy the content to your extension **.js** file (anywhere on the file, outside other functions).
 
 ```javascript
-// *******************************************
-// Model Summary Panel
-// *******************************************
-function ModelSummaryPanel(viewer, container, id, title, options) {
-    this.viewer = viewer;
-    Autodesk.Viewing.UI.PropertyPanel.call(this, container, id, title, options);
+class ModelSummaryPanel extends Autodesk.Viewing.UI.PropertyPanel {
+    constructor(viewer, container, id, title, options) {
+        super(container, id, title, options);
+        this.viewer = viewer;
+    }
 }
-ModelSummaryPanel.prototype = Object.create(Autodesk.Viewing.UI.PropertyPanel.prototype);
-ModelSummaryPanel.prototype.constructor = ModelSummaryPanel;
 ```
 
 ## Implement .onClick function
 
-Now it's time to replace the `Execute an action here` placeholder inside the `.onClick` function. For this sample, let's first show the property panel, then enumerate leaf nodes, then get a specific set of properties for leaf nodes, finally count ocurrences of those properties and show results on the panel. 
+Now it's time to replace the `Execute an action here` placeholder inside the `onClick` function. For this sample, let's first show the property panel, then enumerate leaf nodes, then get a specific set of properties for leaf nodes, finally count ocurrences of those properties and show results on the panel. 
 
-!> In the code below you **MUST** adjust `var propsToList = ['PropName1', 'PropName2'];` to the property names that applies to your models. For instance, as **Material** exists on almost all models, you can try with `var propsToList = ['Material'];`
+!> In the code below you **MUST** adjust `filteredProps` to the property names that applies to your models. For instance, as **Material** exists on almost all models, you can try with `const filteredProps = ['Material'];`
 
-Copy the following content to your extension **.js** file inside the `.onClick = function (e)` function:
+Copy the following content to your extension **.js** file inside the `onClick` function of the extension's button:
 
 ```javascript
-// check if the panel is created or not
-if (_this.panel == null) {
-    _this.panel = new ModelSummaryPanel(_this.viewer, _this.viewer.container, 'modelSummaryPanel', 'Model Summary');
+// Check if the panel is created or not
+if (this._panel == null) {
+    this._panel = new ModelSummaryPanel(this.viewer, this.viewer.container, 'modelSummaryPanel', 'Model Summary');
 }
-// show/hide docking panel
-_this.panel.setVisible(!_this.panel.isVisible());
+// Show/hide docking panel
+this._panel.setVisible(!this._panel.isVisible());
 
-// if panel is NOT visible, exit the function
-if (!_this.panel.isVisible()) return;
-// ok, it's visible, let's get the summary!
+// If panel is NOT visible, exit the function
+if (!this._panel.isVisible())
+    return;
 
-// first, the Viewer contains all elements on the model, including
+// First, the viewer contains all elements on the model, including
 // categories (e.g. families or part definition), so we need to enumerate
 // the leaf nodes, meaning actual instances of the model. The following
 // getAllLeafComponents function is defined at the bottom
-_this.getAllLeafComponents(function (dbIds) {
-
-    // now for leaf components, let's get some properties
-    // and count occurrences of each value.
-    var propsToList = ['PropName1', 'PropName2'];
-
-    // get only the properties we need for the leaf dbIds
-    _this.viewer.model.getBulkProperties(dbIds, propsToList, function (dbIdsProps) {
-
-        // iterate through the elements we found
-        dbIdsProps.forEach(function (item) {
-
+this.getAllLeafComponents((dbIds) => {
+    // Now for leaf components, let's get some properties and count occurrences of each value
+    const filteredProps = ['PropertyNameA', 'PropertyNameB'];
+    // Get only the properties we need for the leaf dbIds
+    this.viewer.model.getBulkProperties(dbIds, filteredProps, (items) => {
+        // Iterate through the elements we found
+        items.forEach((item) => {
             // and iterate through each property
-            item.properties.forEach(function (itemProp) {
-
-                // now use the propsToList to store the count as a subarray
-                if (propsToList[itemProp.displayName] === undefined)
-                    propsToList[itemProp.displayName] = {};
-
-                // now start counting: if first time finding it, set as 1, else +1
-                if (propsToList[itemProp.displayName][itemProp.displayValue] === undefined)
-                    propsToList[itemProp.displayName][itemProp.displayValue] = 1;
+            item.properties.forEach(function (prop) {
+                // Use the filteredProps to store the count as a subarray
+                if (filteredProps[prop.displayName] === undefined)
+                    filteredProps[prop.displayName] = {};
+                // Start counting: if first time finding it, set as 1, else +1
+                if (filteredProps[prop.displayName][prop.displayValue] === undefined)
+                    filteredProps[prop.displayName][prop.displayValue] = 1;
                 else
-                    propsToList[itemProp.displayName][itemProp.displayValue] += 1;
+                    filteredProps[prop.displayName][prop.displayValue] += 1;
             });
         });
-
-        // now ready to show!
-        // the Viewer PropertyPanel has the .addProperty that receives the name, value
+        // Now ready to show!
+        // The PropertyPanel has the .addProperty that receives the name, value
         // and category, that simple! So just iterate through the list and add them
-        propsToList.forEach(function (propName) {
-            if (propsToList[propName] === undefined) return;
-            Object.keys(propsToList[propName]).forEach(function (propValue) {
-                _this.panel.addProperty(
-                    /*name*/     propValue,
-                    /*value*/    propsToList[propName][propValue],
-                    /*category*/ propName);
+        filteredProps.forEach((prop) => {
+            if (filteredProps[prop] === undefined) return;
+            Object.keys(filteredProps[prop]).forEach((val) => {
+                this._panel.addProperty(val, filteredProps[prop][val], prop);
             });
         });
-    })
-})
+    });
+});
 ```
 
 ## Conclusion
@@ -210,7 +175,7 @@ At this point the extension should load and show a toolbar button. Click on the 
 
 ![](_media/javascript/js_dockingpanel.gif)
 
-> As mentioned, you need to define the **propsToList** appropriate for your models. The above video used `['Material', 'Design Status', 'Type Name'];` which works for both models.
+> As mentioned, you need to define the **filteredProps** appropriate for your models. The above video used `['Material', 'Design Status', 'Type Name'];` which works for both models.
 
 Key learning points:
 

--- a/docs/viewer/extensions/selection.md
+++ b/docs/viewer/extensions/selection.md
@@ -7,64 +7,57 @@ This section uses the **basic skeleton** from previous section, but let's rename
 As each extension should be a separeted JavaScript file, create a file in the UI folder **/js/handleselectionextension.js** and copy the following content (which is same as the basic skeleton, except with a different name): 
 
 ```javascript
-// *******************************************
-// Handle Selection Extension
-// *******************************************
-function HandleSelectionExtension(viewer, options) {
-    Autodesk.Viewing.Extension.call(this, viewer, options);
+class HandleSelectionExtension extends Autodesk.Viewing.Extension {
+    constructor(viewer, options) {
+        super(viewer, options);
+        this._group = null;
+        this._button = null;
+    }
+
+    load() {
+        console.log('HandleSelectionExtension has been loaded');
+        return true;
+    }
+
+    unload() {
+        // Clean our UI elements if we added any
+        if (this._group) {
+            this._group.removeControl(this._button);
+            if (this._group.getNumberOfControls() === 0) {
+                this.viewer.toolbar.removeControl(this._group);
+            }
+        }
+        console.log('HandleSelectionExtension has been unloaded');
+        return true;
+    }
+
+    onToolbarCreated() {
+        // Create a new toolbar group if it doesn't exist
+        this._group = this.viewer.toolbar.getControl('allMyAwesomeExtensionsToolbar');
+        if (!this._group) {
+            this._group = new Autodesk.Viewing.UI.ControlGroup('allMyAwesomeExtensionsToolbar');
+            this.viewer.toolbar.addControl(this._group);
+        }
+
+        // Add a new button to the toolbar group
+        this._button = new Autodesk.Viewing.UI.Button('handleSelectionExtensionButton');
+        this._button.onClick = (ev) => {
+            // Execute an action here
+        };
+        this._button.setToolTip('Handle Selection Extension');
+        this._button.addClass('handleSelectionExtensionIcon');
+        this._group.addControl(this._button);
+    }
 }
-
-HandleSelectionExtension.prototype = Object.create(Autodesk.Viewing.Extension.prototype);
-HandleSelectionExtension.prototype.constructor = HandleSelectionExtension;
-
-HandleSelectionExtension.prototype.load = function () {
-    // any custom initialization required? add here
-    return true;
-};
-
-HandleSelectionExtension.prototype.onToolbarCreated = function () {
-    var _this = this;
-
-    // prepare to execute the button action
-    var handleSelectionToolbarButton = new Autodesk.Viewing.UI.Button('handleSelectionButton');
-    handleSelectionToolbarButton.onClick = function (e) {
-       
-        // **********************
-        //
-        //
-        // Execute an action here
-        //
-        //
-        // **********************
-
-    };
-    // handleSelectionToolbarButton CSS class should be defined on your .css file
-    // you may include icons, below is a sample class:
-    handleSelectionToolbarButton.addClass('handleSelectionToolbarButton');
-    handleSelectionToolbarButton.setToolTip('Handle current selection');
-
-    // SubToolbar
-    this.subToolbar = (this.viewer.toolbar.getControl("MyAppToolbar") ?
-        this.viewer.toolbar.getControl("MyAppToolbar") :
-        new Autodesk.Viewing.UI.ControlGroup('MyAppToolbar'));
-    this.subToolbar.addControl(handleSelectionToolbarButton);
-
-    this.viewer.toolbar.addControl(this.subToolbar);
-};
-
-HandleSelectionExtension.prototype.unload = function () {
-    if (this.viewer.toolbar) this.viewer.toolbar.removeControl(this.subToolbar);
-    return true;
-};
 
 Autodesk.Viewing.theExtensionManager.registerExtension('HandleSelectionExtension', HandleSelectionExtension);
 ```
 ## Toolbar CSS
 
-Just like in the basic skeleton, the toolbar button uses a **CSS** styling (see call to `.addClass` on the code). In the **/css/main.css** add the following:
+Just like in the basic skeleton, the toolbar button uses a **CSS** styling. In the **/css/main.css** add the following:
 
 ```css
-.handleSelectionToolbarButton {
+.handleSelectionExtensionIcon {
     background-image: url(https://github.com/encharm/Font-Awesome-SVG-PNG/raw/master/white/png/24/object-group.png);
     background-size: 24px;
     background-repeat: no-repeat;
@@ -106,41 +99,31 @@ At this point the extension should load with a toolbar icon, but it doesn't do a
 
 ## Implement .onClick function
 
-Now it's time to replace the `Execute an action here` placeholder inside the `.onClick` function. For this sample, let's isolate the selection. Copy the following content to your extension **.js** file inside the `.onClick = function (e)` function:
+Now it's time to replace the `Execute an action here` placeholder inside the `.onClick` function. For this sample, let's isolate the selection. Copy the following content to your extension **.js** file inside the `.onClick` function:
 
 ```javascript
-/// get current selection
-var selection = _this.viewer.getSelection();
-_this.viewer.clearSelection();
-// anything selected?
+// Get current selection
+const selection = this.viewer.getSelection();
+this.viewer.clearSelection();
+// Anything selected?
 if (selection.length > 0) {
-    // create an array to store dbIds to isolate
-    var dbIdsToChange = [];
-
-    // iterate through the list of selected dbIds
-    selection.forEach(function (dbId) {
-        // get properties of each dbId
-        _this.viewer.getProperties(dbId, function (props) {
-            // output on console, for fun...
+    let isolated = [];
+    // Iterate through the list of selected dbIds
+    selection.forEach((dbId) => {
+        // Get properties of each dbId
+        this.viewer.getProperties(dbId, (props) => {
+            // Output properties to console
             console.log(props);
-
-            // ask if want to isolate
-            if (confirm('Confirm ' + props.name + ' (' + props.externalId + ')?')) {
-                dbIdsToChange.push(dbId);
-
-                // at this point we know which elements to isolate
-                if (dbIdsToChange.length > 0) {
-                    // isolate selected (and confirmed) dbIds
-                    _this.viewer.isolate(dbIdsToChange);
-                }
+            // Ask if want to isolate
+            if (confirm(`Isolate ${props.name} (${props.externalId})?`)) {
+                isolated.push(dbId);
+                this.viewer.isolate(isolated);
             }
-        })
-    })
-
-}
-else {
-    // if nothing selected, restore
-    _this.viewer.isolate(0);
+        });
+    });
+} else {
+    // If nothing selected, restore
+    this.viewer.isolate(0);
 }
 ```
 
@@ -156,7 +139,7 @@ Key learning points:
 
 - **.getSelection()** returns an array of **dbId** from the model, and **.clearSelection()**
 - **.getProperties()** is an asynchronous method that returns all properties for a given dbId via callback, which is widelly used on Viewer, [learn more about callbacks](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function)
-- **.isolate()** method make all other elements transparents (ghost)
+- **.isolate()** method makes all other elements transparent ("ghosted")
 
 Additional learning points:
 

--- a/docs/viewer/extensions/skeleton.md
+++ b/docs/viewer/extensions/skeleton.md
@@ -41,8 +41,11 @@ class MyAwesomeExtension extends Autodesk.Viewing.Extension {
 
         // Add a new button to the toolbar group
         this._button = new Autodesk.Viewing.UI.Button('myAwesomeExtensionButton');
-        this._button.onClick = (ev) => { alert('Hello World!'); };
+        this._button.onClick = (ev) => {
+            // Execute an action here
+        };
         this._button.setToolTip('My Awesome Extension');
+        this._button.addClass('myAwesomeExtensionIcon');
         this._group.addControl(this._button);
     }
 }
@@ -57,7 +60,7 @@ Autodesk.Viewing.theExtensionManager.registerExtension('MyAwesomeExtension', MyA
 The toolbar button uses a **CSS** styling (see call to `.addClass` on the code). At the **/css/main.css** add the following:
 
 ```css
-#myAwesomeExtensionButton {
+.myAwesomeExtensionIcon {
     background-image: url(/img/myAwesomeIcon.png);
     background-size: 24px;
     background-repeat: no-repeat;

--- a/docs/viewer/extensions/skeleton.md
+++ b/docs/viewer/extensions/skeleton.md
@@ -7,58 +7,45 @@ This step of the tutorial describes the basic skeleton of an extension with a to
 Let's get started, each extension should be a JavaScript file and implement, at least, the `.load` and `.unload` functions. Create a file in the UI folder **/js/myawesomeextension.js** and copy the following content. 
 
 ```javascript
-// *******************************************
-// My Awesome Extension
-// *******************************************
-function MyAwesomeExtension(viewer, options) {
-    Autodesk.Viewing.Extension.call(this, viewer, options);
+class MyAwesomeExtension extends Autodesk.Viewing.Extension {
+    constructor(viewer, options) {
+        super(viewer, options);
+        this._group = null;
+        this._button = null;
+    }
+
+    load() {
+        console.log('MyAwesomeExtensions has been loaded');
+        return true;
+    }
+
+    unload() {
+        // Clean our UI elements if we added any
+        if (this._group) {
+            this._group.removeControl(this._button);
+            if (this._group.getNumberOfControls() === 0) {
+                this.viewer.toolbar.removeControl(this._group);
+            }
+        }
+        console.log('MyAwesomeExtensions has been unloaded');
+        return true;
+    }
+
+    onToolbarCreated() {
+        // Create a new toolbar group if it doesn't exist
+        this._group = this.viewer.toolbar.getControl('allMyAwesomeExtensionsToolbar');
+        if (!this._group) {
+            this._group = new Autodesk.Viewing.UI.ControlGroup('allMyAwesomeExtensionsToolbar');
+            this.viewer.toolbar.addControl(this._group);
+        }
+
+        // Add a new button to the toolbar group
+        this._button = new Autodesk.Viewing.UI.Button('myAwesomeExtensionButton');
+        this._button.onClick = (ev) => { alert('Hello World!'); };
+        this._button.setToolTip('My Awesome Extension');
+        this._group.addControl(this._button);
+    }
 }
-
-MyAwesomeExtension.prototype = Object.create(Autodesk.Viewing.Extension.prototype);
-MyAwesomeExtension.prototype.constructor = MyAwesomeExtension;
-
-MyAwesomeExtension.prototype.load = function () {
-    // any custom initialization required? add here
-    return true;
-};
-
-MyAwesomeExtension.prototype.onToolbarCreated = function () {
-    var _this = this;
-
-    // prepare to execute the button action
-    var myAwesomeToolbarButton = new Autodesk.Viewing.UI.Button('runMyAwesomeCode');
-    myAwesomeToolbarButton.onClick = function (e) {
-
-        // **********************
-        //
-        //
-        // Execute an action here
-        //
-        //
-        // **********************
-
-        alert('I am an extension');
-
-    };
-    // myAwesomeToolbarButton CSS class should be defined on your .css file
-    // you may include icons, below is a sample class:
-    myAwesomeToolbarButton.addClass('myAwesomeToolbarButton');
-    myAwesomeToolbarButton.setToolTip('My Awesome extension');
-
-    // SubToolbar
-    this.subToolbar = (this.viewer.toolbar.getControl("MyAppToolbar") ?
-        this.viewer.toolbar.getControl("MyAppToolbar") :
-        new Autodesk.Viewing.UI.ControlGroup('MyAppToolbar'));
-    this.subToolbar.addControl(myAwesomeToolbarButton);
-
-    this.viewer.toolbar.addControl(this.subToolbar);
-};
-
-MyAwesomeExtension.prototype.unload = function () {
-    // remove toolbar
-    if (this.viewer.toolbar) this.viewer.toolbar.removeControl(this.subToolbar);
-    return true;
-};
 
 Autodesk.Viewing.theExtensionManager.registerExtension('MyAwesomeExtension', MyAwesomeExtension);
 ```
@@ -70,7 +57,7 @@ Autodesk.Viewing.theExtensionManager.registerExtension('MyAwesomeExtension', MyA
 The toolbar button uses a **CSS** styling (see call to `.addClass` on the code). At the **/css/main.css** add the following:
 
 ```css
-.myAwesomeToolbarButton {
+#myAwesomeExtensionButton {
     background-image: url(/img/myAwesomeIcon.png);
     background-size: 24px;
     background-repeat: no-repeat;


### PR DESCRIPTION
The viewer extension examples now:

- use ES6 classes instead of prototypes
- clean after themselves more properly (only removing the toolbar group when it's empty)
- use fat-arrow functions (to avoid storing `_this`)
- enumerate tree nodes in a simplified way