### PR TITLE
Get engines paginated

### DIFF
--- a/docs/designautomation/appbundle/netcore.md
+++ b/docs/designautomation/appbundle/netcore.md
@@ -2,7 +2,7 @@
 
 ## DesignAutomationController.cs
 
-Under **Controllers** folder create a `DesignAutomationController.cs` with the following content. This is just the class, we'll define the endpoints later, but note the `DesignAutomationHub` at the end, which allow us push notifications to the client via [SignalR](https://docs.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-2.2).
+Under **Controllers** folder create a `DesignAutomationController.cs` with the following content. This is just the class, we'll define the endpoints later, but note the `DesignAutomationHub` at the end, which allow us push notifications to the client via [SignalR](https://docs.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-3.1).
 
 ```csharp
 using Autodesk.Forge;
@@ -106,12 +106,22 @@ To define a bundle we also need the engine, so this endpoint return a list of al
 public async Task<List<string>> GetAvailableEngines()
 {
     dynamic oauth = await OAuthController.GetInternalAsync();
-
+    List<string> allEngines = new List<string>();
+    
     // define Engines API
-    Page<string> engines = await _designAutomation.GetEnginesAsync();
-    engines.Data.Sort();
-
-    return engines.Data; // return list of engines
+    string paginationToken = null;
+    while (true)
+    {
+        Page<string> engines = await _designAutomation.GetEnginesAsync(paginationToken);
+        allEngines.AddRange(engines.Data);
+        if (engines.PaginationToken == null)
+            break;
+            
+        paginationToken = engines.PaginationToken;
+    } 
+    allEngines.Sort();
+    
+    return allEngines; // return list of engines
 }
 ```
 


### PR DESCRIPTION
Changed the GetAvailableEngines method to retrieve the engines not only from the first page.