### PR TITLE
fix dashboard

### DIFF
--- a/docs/viewer/dashboard/layout.md
+++ b/docs/viewer/dashboard/layout.md
@@ -16,10 +16,11 @@ $(document).ready(function () {
         if ($(e.target).hasClass('orbit-gizmo')) {
             // to make sure we get the viewer, let's use the global var NOP_VIEWER
             if (NOP_VIEWER === null || NOP_VIEWER === undefined) return;
-            new Dashboard(NOP_VIEWER, [
+            let newDash = new Dashboard(NOP_VIEWER, [
                 new BarChart('Material'),
                 new PieChart('Material')
-            ])
+            ]);
+            newDash._viewer.addEventListener(Autodesk.Viewing.GEOMETRY_LOADED_EVENT, newDash.loadPanels());
         }
     });
 })
@@ -31,15 +32,16 @@ class Dashboard {
         this._viewer = viewer;
         this._panels = panels;
         this.adjustLayout();
-        this._viewer.addEventListener(Autodesk.Viewing.GEOMETRY_LOADED_EVENT, (viewer) => {
-            _this.loadPanels();
-        });
     }
 
     adjustLayout() {
         // this function may vary for layout to layout...
         // for learn forge tutorials, let's get the ROW and adjust the size of the 
         // columns so it can fit the new dashboard column, also we added a smooth transition css class for a better user experience
+        let dashdiv = document.getElementById('dashboard');
+        if(!!dashdiv){
+            dashdiv.parentElement.removeChild(dashdiv);
+        }
         var row = $(".row").children();
         $(row[0]).removeClass('col-sm-4').addClass('col-sm-2 transition-width');
         $(row[1]).removeClass('col-sm-8').addClass('col-sm-7 transition-width').after('<div class="col-sm-3 transition-width" id="dashboard"></div>');


### PR DESCRIPTION
Remove listener from the object constructor on docs/viewer/dashboard/layout.md :
```
this._viewer.addEventListener(Autodesk.Viewing.GEOMETRY_LOADED_EVENT, (viewer) => {
    _this.loadPanels();
});
```
Return an instance of Dashboard and add event listener outside object constructor on docs/viewer/dashboard/layout.md:
```
let newDash = new Dashboard(NOP_VIEWER, [
    new BarChart('Material'),
    new PieChart('Material')
]);
newDash._viewer.addEventListener(Autodesk.Viewing.GEOMETRY_LOADED_EVENT, newDash.loadPanels());
```
Divs were being added indefinitely to index on docs/viewer/dashboard/layout.md:
```
let dashdiv = document.getElementById('dashboard');
if(!!dashdiv){
    dashdiv.parentElement.removeChild(dashdiv);
}
```